### PR TITLE
Fix continual disconnect

### DIFF
--- a/octoprint_mqtt/__init__.py
+++ b/octoprint_mqtt/__init__.py
@@ -179,7 +179,9 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
 				pass
 
 		subbed_topics = list(map(lambda t: (t, 0), {topic for topic, _, _, _ in self._mqtt_subscriptions}))
-		self._mqtt.subscribe(subbed_topics)
+		if subbed_topics:
+			self._mqtt.subscribe(subbed_topics)
+			self._logger.debug("Subscribed to topics")
 
 		self._mqtt_connected = True
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ plugin_package = "octoprint_%s" % plugin_identifier
 plugin_name = "OctoPrint-MQTT"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1"
+plugin_version = "0.2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Fixes the case where you don't have any MQTT subscriptions, otherwise MQTT client continually disconnects from broker.

#### How was it tested? How can it be tested by the reviewer?
Use a very vanilla setup, no extra MQTT plugins, you'll see disconnects. With this change, no problem.

#### What are the relevant tickets if any?
* #6