### PR TITLE
Add SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,23 @@ plugins:
             # the keepalive value for the broker connection
             #keepalive: 60
 
+            # tls settings
+            #tls:
+                # path to the server's certificate file
+                #ca_certs: unset
+
+                # paths to the PEM encoded client certificate and private keys
+                # respectively, must not be password protected, only necessary
+                # if broker requires client certificate authentication
+                #certfile: unset
+                #keyfile: unest
+
+                # a string specifying which encryption ciphers are allowable for this connection
+                #ciphers: unset
+
+            # configure verification of the server hostname in the server certificate.
+            #tls_insecure: false
+
         publish:
             # base topic under which to publish OctoPrint's messages
             #baseTopic: octoprint/

--- a/octoprint_mqtt/__init__.py
+++ b/octoprint_mqtt/__init__.py
@@ -44,7 +44,9 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
 				port=1883,
 				username=None,
 				password=None,
-				keepalive=60
+				keepalive=60,
+				tls=dict(),
+				tls_insecure=False
 			),
 			publish=dict(
 				baseTopic="octoprint/",
@@ -69,13 +71,15 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
 	##~~ helpers
 
 	def mqtt_connect(self):
-		# TODO TLS, LWT, protocol
+		# TODO LWT, protocol
 
 		broker_url = self._settings.get(["broker", "url"])
 		broker_port = self._settings.get_int(["broker", "port"])
 		broker_username = self._settings.get(["broker", "username"])
 		broker_password = self._settings.get(["broker", "password"])
 		broker_keepalive = self._settings.get_int(["broker", "keepalive"])
+		broker_tls = self._settings.get(["broker", "tls"], asdict=True)
+		broker_tls_insecure = self._settings.get_boolean(["broker", "tls_insecure"])
 
 		if broker_url is None:
 			return
@@ -87,6 +91,12 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
 
 		if broker_username is not None:
 			self._mqtt.username_pw_set(broker_username, password=broker_password)
+
+		if broker_tls:
+			self._mqtt.tls_set(**broker_tls)
+
+		if broker_tls_insecure is not None:
+			self._mqtt.tls_insecure_set(broker_tls_insecure)
 
 		self._mqtt.on_connect = self._on_mqtt_connect
 		self._mqtt.on_disconnect = self._on_mqtt_disconnect


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Adds ability to configure SSL support, allowing users to encrypt their traffic and connect to brokers that only allow SSL connections.

#### How was it tested? How can it be tested by the reviewer?
Set up an MQTT broker with SSL authentication and configure the plugin

#### What are the relevant tickets if any?
* OctoPrint/OctoPrint-MQTT#3

#### Further notes
A UI to configure and upload certificates would be a great improvement, but this at least adds the support.