### PR TITLE
Publish progress via ProgressPlugin mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ plugins:
             # topic for events, appended to the base topic, '{event}' will
             # be substituted with the event name
             #eventTopic: event/{event}
+
+            # topic for print and slicer progress, appended to the base topic, 
+            # '{progress}' will be substituted with either 'printing' or 'slicing'
+            #progressTopic: progress/{progress}
 ```
 
 ## Helpers


### PR DESCRIPTION
Publish the print and slicer progress using the ProgressPlugin mixin as requested in foosel/OctoPrint#1810

Unfortunately I can't really test this because I don't have a MQTT setup. Maybe someone can test this?

Also I don't know if it is a good idea to include the slicer progress here since that will probably result in a LOT of MQTT messages over a very short time.