### PR TITLE
Add timestamp to temperature message

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ Examples:
 | octoprint/progress/slicing   | `{"progress": 42, "source_location": "local", "source_path": "test.stl", "destination_location": "local", "destination_path": "test.gcode", "slicer": "cura"}` |
 
 The plugin also publishes the temperatures of the tools and the bed to `octoprint/temperature/<tool>` where `<tool>` will either
-be 'bed' or 'toolX' (X is the number of the tool). The payload will contain the `actual` and the `target` temperature as floating point value. 
+be 'bed' or 'toolX' (X is the number of the tool). The payload will contain the `actual` and the `target` temperature as floating point value plus the current `time` as unix timestamp in seconds.
 New messages will not be published constantly, but only when a value changes. The published messages will be marked as retained.
 
 Examples:
 
 | Topic                        | Message                                                          |
 |------------------------------|------------------------------------------------------------------|
-| octoprint/temperature/tool0  | `{"actual": 65.3, "target": 210.0}`                              |
-| octoprint/temperature/bed    | `{"actual": 42.1, "target": 65.0}`                               |
+| octoprint/temperature/tool0  | `{"time": 1517190629, "actual": 65.3, "target": 210.0}`                              |
+| octoprint/temperature/bed    | `{"time": 1517190629, "actual": 42.1, "target": 65.0}`                               |
 
 You are able to deactivate topics in the settings. This allows you to e.g. only send temperature messages when you don't
 need event or progress messages.

--- a/octoprint_mqtt/__init__.py
+++ b/octoprint_mqtt/__init__.py
@@ -133,7 +133,8 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
 						or value["actual"] != self.lastTemp[key]["actual"] \
 						or value["target"] != self.lastTemp[key]["target"]:
 					# unknown key, new actual or new target -> update mqtt topic!
-					dataset = dict(actual=value["actual"],
+					dataset = dict(time=data["time"],
+					               actual=value["actual"]),
 					               target=value["target"])
 					self.mqtt_publish(topic.format(temp=key), json.dumps(dataset), retained=True, allow_queueing=True)
 					self.lastTemp.update({key:data[key]})


### PR DESCRIPTION
I am currently experimenting with a water cooled hotend. Therefore, I want to store the current hotend temperature in addition to the water temperature in my opentsdb storage.

However, without a timestamp inside the MQTT message, this is currently complicated. Since, adding the timestamp on message arrival at the bridging node.js script is possible, but would also apply to every retained message that you receive on connecting to the broker. So, it would be storing the value again with a wrong timestamp in the database.

Hence, I adjusted the plugin to also send the current unix timestamp in seconds with the message.

I don't know if this is also useful for other people.