### PR TITLE
Reset progress and filename on FILE_SELECTED and FILE_DESELECTED events.

### DIFF
--- a/octoprint_mqtt/__init__.py
+++ b/octoprint_mqtt/__init__.py
@@ -154,6 +154,10 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
 			self.on_print_progress(payload["origin"], payload["path"], 0)
 		elif event == Events.PRINT_DONE:
 			self.on_print_progress(payload["origin"], payload["path"], 100)
+		elif event == Events.FILE_SELECTED:
+			self.on_print_progress(payload["origin"], payload["path"], 0)
+		elif event == Events.FILE_DESELECTED:
+			self.on_print_progress("", "", 0)
 
 		topic = self._get_topic("event")
 


### PR DESCRIPTION
Hi.

I noticed the progress and filename data doesn't get reset when you load a new file for printing. Also when deleting a previously loaded file (which clears it from the printer 'State' pane). 

Thanks for all your hard work! 👍 