### PR TITLE
fix NoneType errors on temperatures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ plugin_package = "octoprint_mqtt"
 plugin_name = "OctoPrint-MQTT"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.8.0"
+plugin_version = "0.8.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Fixes #42 and #56, which is almost exactly the same thing. I'd forgotten this wasn't merged when @jneilliii took over the repo and released "0.8.0".

Needs some refreshed testing, please note on the PR if you have installed the PR version and it works/fails.
    
You can install this PR by using the following URL in your plugin install "from URL" panel. I think.
    
    https://github.com/OctoPrint/OctoPrint-MQTT/archive/201811_safer_temperature_evaluation_d.zip
