### PR TITLE
mask empty temperatures, eg bed or chamber

### DIFF
--- a/octoprint_mqtt/__init__.py
+++ b/octoprint_mqtt/__init__.py
@@ -219,7 +219,7 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
 					continue
 
 				# skip any entries that are none or zero.
-				if not value.get("actual") and not value.get("target"):
+				if not (value.get("actual") and value.get("target")):
 					continue
 
 				# in issue #42 the problem wasn't a failure to get the key, but

--- a/octoprint_mqtt/__init__.py
+++ b/octoprint_mqtt/__init__.py
@@ -219,7 +219,7 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
 					continue
 
 				# skip any entries that are none or zero.
-				if not (value.get("actual") and value.get("target")):
+				if not (value.get("actual") or value.get("target")):
 					continue
 
 				# in issue #42 the problem wasn't a failure to get the key, but

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ plugin_package = "octoprint_mqtt"
 plugin_name = "OctoPrint-MQTT"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.8.2"
+plugin_version = "0.8.3"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
- Fixes #61 and probably fixes a case where the bed isn't heated too.
- use `six` to check for stringiness. Should help with py2/py3.
- adjusted some whitespace per `flake`.
- prep for release


I'm going to let this bake on my Pis for a day or two.