### PR TITLE
push 'retain' flag to publish-time only

### DIFF
--- a/octoprint_mqtt/templates/mqtt_settings.jinja2
+++ b/octoprint_mqtt/templates/mqtt_settings.jinja2
@@ -45,6 +45,15 @@
 			<div class="control-group">
 				<div class="controls">
 					<label class="checkbox">
+						<input type="checkbox" data-bind="checked: settings.broker.retain" /> {{ _('Enable retain flag') }}
+					  <span class="help-block">{{ _('Enable or disable retain flag through entire plugin') }}</span>
+					</label>
+				</div>
+			</div>
+
+			<div class="control-group">
+				<div class="controls">
+					<label class="checkbox">
 						<input type="checkbox" data-bind="checked: showClientID"> {{ _('The broker requires static client id, show options') }}
 					</label>
 				</div>

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ plugin_package = "octoprint_mqtt"
 plugin_name = "OctoPrint-MQTT"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.8.3"
+plugin_version = "0.8.4"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
- instead of passing in a retain flag, move it to a config option and don't even determine what to do until publish-time. If we want it to be more granular later, we can, but it needs more info than "boolean" to capture it- e.g. we need to capture "do whatever the default is" in addition to a bool. yolo.
- add to template
- add retain debug line
- make sure to retain on the queue too


@jneilliii please review; the log entry shows 'true' when expected, but `mosquitto_sub`'s %r option never changes from nonzero. I need to look at it more, unless you see something obvious. It might be that "fresh" messages never have the retain bit, but I haven't confirmed that.

Fixes #55.