### PR TITLE
Python3 and OctoPrint 1.4.0

### DIFF
--- a/octoprint_mqtt/__init__.py
+++ b/octoprint_mqtt/__init__.py
@@ -209,6 +209,7 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
 				if key == "time":
 					continue
 
+				if not value["actual"]: continue
 				if key not in self.lastTemp \
 						or abs(value["actual"] - self.lastTemp[key]["actual"]) >= threshold \
 						or value["target"] != self.lastTemp[key]["target"]:
@@ -328,6 +329,10 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
 		return self.mqtt_publish(topic, payload, retained=retained, qos=qos, allow_queueing=allow_queueing)
 
 	def mqtt_publish(self, topic, payload, retained=False, qos=0, allow_queueing=False):
+		try:
+			basestring
+		except NameError:
+			basestring = (str, bytes)
 		if not isinstance(payload, basestring):
 			payload = json.dumps(payload)
 
@@ -452,6 +457,7 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
 
 
 __plugin_name__ = "MQTT"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
 	plugin = MqttPlugin()

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ plugin_additional_packages = []
 # Any python packages within <plugin_package>.* you do NOT want to install with your plugin
 plugin_ignored_packages = []
 
-
 # Additional parameters for the call to setuptools.setup. If your plugin wants to register additional entry points,
 # define dependency links or other things like that, this is the place to go. Will be merged recursively with the
 # default setup parameters as provided by octoprint_setuptools.create_plugin_setup_parameters using

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ plugin_additional_packages = []
 # Any python packages within <plugin_package>.* you do NOT want to install with your plugin
 plugin_ignored_packages = []
 
+
 # Additional parameters for the call to setuptools.setup. If your plugin wants to register additional entry points,
 # define dependency links or other things like that, this is the place to go. Will be merged recursively with the
 # default setup parameters as provided by octoprint_setuptools.create_plugin_setup_parameters using


### PR DESCRIPTION
This PR will fix #79 by:
* Adding `__plugin_pythoncompat__` variable
* Fixing basestring errors with python3
* Fixing error "None" cannot subtract from "None" when temperatures dictionary has the value "None".

Translated to features:
- Compatibility with python3 and python2
- Compatibility with OctoPrint 1.4.0

