### PR TITLE
Reset printing and slicing progress after restart

### DIFF
--- a/octoprint_mqtt/__init__.py
+++ b/octoprint_mqtt/__init__.py
@@ -47,6 +47,7 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
 	def __init__(self):
 		self._mqtt = None
 		self._mqtt_connected = False
+		self._mqtt_reset_state = True
 
 		self._mqtt_subscriptions = []
 
@@ -409,6 +410,11 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
 			self._logger.debug("Subscribed to topics")
 
 		self._mqtt_connected = True
+
+		if self._mqtt_reset_state:
+			self.on_print_progress("", "", 0)
+			self.on_slicing_progress("", "", "", "", "", 0)
+			self._mqtt_reset_state = False
 
 	def _on_mqtt_disconnect(self, client, userdata, rc):
 		if not client == self._mqtt:


### PR DESCRIPTION
When using this plugin with the retain option enabled, it's likely to get out of date progress for slicing and printing when restarting OctoPrint.

In a normal workflow, this plugin will reset the printing state back to "0" any time a new file is selected in the UI. Often times though when completing a print, I shut down my printer before clearing this state (and sending the corresponding event). In this case the printing progress is not reset on the MQTT service (when using retain).

To fix the issue, this change tracks the startup state and publishes a state reset after completing the first connection to the MQTT service.