### PR TITLE
Add option to publish raw data

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,12 +157,12 @@ plugins:
 
 ## Helpers
 
-### mqtt_publish(topic, payload, retained=False, qos=0, allow_queueing=False)
+### mqtt_publish(topic, payload, retained=False, qos=0, allow_queueing=False, raw_data=False)
 
 Publishes `payload` to `topic`. If `retained` is set to `True`, message will be flagged to be retained by the
 broker. The QOS setting can be overridden with the `qos` parameter.
 
-`payload` may be a string in which case it will be sent as is. Otherwise a value conversion to JSON will be performed.
+`payload` may be a string in which case it will be sent as is. Otherwise a value conversion to JSON will be performed, unless you set `raw_data` to `True`.
 
 If the MQTT plugin is currently not connected to the broker but `allow_queueing` is `True`, the message will be
 stored internally and published upon connection to the broker.

--- a/octoprint_mqtt/__init__.py
+++ b/octoprint_mqtt/__init__.py
@@ -328,8 +328,8 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
 
 		return self.mqtt_publish(topic, payload, retained=retained, qos=qos, allow_queueing=allow_queueing)
 
-	def mqtt_publish(self, topic, payload, retained=False, qos=0, allow_queueing=False):
-		if not isinstance(payload, basestring):
+	def mqtt_publish(self, topic, payload, retained=False, qos=0, allow_queueing=False, raw_data=False):
+		if not (isinstance(payload, basestring) or raw_data):
 			payload = json.dumps(payload)
 
 		if not self._mqtt_connected:


### PR DESCRIPTION
After unsuccessfully trying to publish an image to an MQTT topic (to create a camera in Home Assistant) I discovered that the payload is always converted to a string, which works fine for an array or a dict, but not so much for binary data. So I have added an option which allows a user to override this behavior and make it possible to publish raw data.
This should not break any existing functionality and I have verified that the binary data my MQTT client received from the topic is the same JPEG that I published from Octoprint.