### PR TITLE
Improvement to retain usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ plugins:
             # configure protocol version to use, valid values: MQTTv31 and MQTTv311
             #protocol: MQTTv31
 
+            # should mqtt connection status / last will be retained?
+            #lwRetain: true
+
         publish:
             # base topic under which to publish OctoPrint's messages
             #baseTopic: octoprint/

--- a/octoprint_mqtt/__init__.py
+++ b/octoprint_mqtt/__init__.py
@@ -102,6 +102,7 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
                 tls_insecure=False,
                 protocol="MQTTv31",
                 retain=True,
+                lwRetain=True,
                 clean_session=True
             ),
             publish=dict(
@@ -181,7 +182,12 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
                 else:
                     data = dict(payload)
                 data["_event"] = event
-                self.mqtt_publish_with_timestamp(topic.format(event=event), data)
+
+                _retained = self._settings.get_boolean(["broker", "retain"])
+                if not _retained or event not in ["ZChange", "FirmwareData"]:
+                    _retained = False
+
+                self.mqtt_publish_with_timestamp(topic.format(event=event), data, retained=_retained)
 
     ##~~ ProgressPlugin API
 
@@ -196,7 +202,7 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
             if self._settings.get_boolean(["publish", "printerData"]):
                 data['printer_data'] = self._printer.get_current_data()
 
-            self.mqtt_publish_with_timestamp(topic.format(progress="printing"), data, retained=True)
+            self.mqtt_publish_with_timestamp(topic.format(progress="printing"), data)
 
     def on_slicing_progress(self, slicer, source_location, source_path, destination_location, destination_path, progress):
         topic = self._get_topic("progress")
@@ -282,6 +288,7 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
         clean_session = self._settings.get_boolean(["broker", "clean_session"])
 
         lw_active = self._settings.get_boolean(["publish", "lwActive"])
+        lw_retain = self._settings.get_boolean(["broker", "lwRetain"])
         lw_topic = self._get_topic("lw")
 
         if broker_url is None:
@@ -313,9 +320,8 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
         if broker_tls_insecure and tls_active:
             self._mqtt.tls_insecure_set(broker_tls_insecure)
 
-        _retain = self._settings.get_boolean(["broker", "retain"])
         if lw_active and lw_topic:
-            self._mqtt.will_set(lw_topic, self.LWT_DISCONNECTED, qos=1, retain=_retain)
+            self._mqtt.will_set(lw_topic, self.LWT_DISCONNECTED, qos=1, retain=lw_retain)
 
         self._mqtt.on_connect = self._on_mqtt_connect
         self._mqtt.on_disconnect = self._on_mqtt_disconnect
@@ -333,7 +339,7 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
             if lwt is None:
                 lwt = self._get_topic("lw")
             if lwt:
-                _retain = self._settings.get_boolean(["broker", "retain"])
+                _retain = self._settings.get_boolean(["broker", "lwRetain"])
                 self._mqtt.publish(lwt, self.LWT_DISCONNECTED, qos=1, retain=_retain)
 
         self._mqtt.loop_stop()
@@ -342,7 +348,7 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
             time.sleep(1)
             self._mqtt.loop_stop(force=True)
 
-    def mqtt_publish_with_timestamp(self, topic, payload, retained=False, qos=0, allow_queueing=False, timestamp=None):
+    def mqtt_publish_with_timestamp(self, topic, payload, retained=None, qos=0, allow_queueing=False, timestamp=None):
         if not payload:
             payload = dict()
         if not isinstance(payload, dict):
@@ -354,9 +360,12 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
         timestamp_fieldname = self._settings.get(["timestamp_fieldname"])
         payload[timestamp_fieldname] = int(timestamp)
 
+        if retained is None:
+            retained = self._settings.get_boolean(["broker", "retain"])
+
         return self.mqtt_publish(topic, payload, retained=retained, qos=qos, allow_queueing=allow_queueing)
 
-    def mqtt_publish(self, topic, payload, retained=False, qos=0, allow_queueing=False, raw_data=False):
+    def mqtt_publish(self, topic, payload, retained=None, qos=0, allow_queueing=False, raw_data=False):
         if not (isinstance(payload, six.string_types) or raw_data):
             payload = json.dumps(payload)
 
@@ -368,7 +377,10 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
             else:
                 return False
 
-        _retain = self._settings.get_boolean(["broker", "retain"])
+        _retain = retained
+        if retained is None:
+            _retain = self._settings.get_boolean(["broker", "retain"])
+
         self._mqtt.publish(topic, payload=payload, retain=_retain, qos=qos)
         self._logger.debug("Sent message: {topic} - {payload}, retain={_retain}".format(**locals()))
         return True
@@ -425,10 +437,11 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
         self._logger.info("Connected to mqtt broker")
         lw_active = self._settings.get_boolean(["publish", "lwActive"])
         lw_topic = self._get_topic("lw")
-        _retain = self._settings.get_boolean(["broker", "retain"])
+        lw_retain = self._settings.get_boolean(["broker", "lwRetain"])
         if lw_active and lw_topic:
-            self._mqtt.publish(lw_topic, self.LWT_CONNECTED, qos=1, retain=_retain)
+            self._mqtt.publish(lw_topic, self.LWT_CONNECTED, qos=1, retain=lw_retain)
 
+        _retain = self._settings.get_boolean(["broker", "retain"])
         if self._mqtt_publish_queue:
             try:
                 while True:

--- a/octoprint_mqtt/templates/mqtt_settings.jinja2
+++ b/octoprint_mqtt/templates/mqtt_settings.jinja2
@@ -306,6 +306,13 @@
                 </div>
             </div>
             <div class="control-group">
+                <div class="controls">
+                    <label class="checkbox">
+                        <input type="checkbox" data-bind="checked: settings.broker.lwRetain" /> {{ _('Retain Last Will & Status publication') }}
+                    </label>
+                </div>
+            </div>
+            <div class="control-group">
                 <label class="control-label">{{ _('Topic') }}</label>
                 <div class="controls">
                     <div class="input-prepend">


### PR DESCRIPTION
A few general improvements to the way retain is used, fixing a couple of bugs.

- LWT topic now has it's own setting for retain. Generally even when you chose NOT to retain other topics, the LWT topic is desired to always be retained since any clients listening to the topic will need to know if the device has an active session with the MQTT server.

CLOSES: #94, #72

- Fixing support for use of the **retained** argument in calls to `mqtt_publish()`. To preserve current behaviour to any callers which do not specify this param its default value is None which will revert to the global settings. Otherwise the value passed is the value that is used.

CLOSES: #81 

- Events will now default to never being retained. Due to the way events are published, they are fundamentally stateless and retaining them has no practical value. The exception is **ZChange** and **FirmwareData** which will respect the global retain settings still.

CLOSES: #76 