### PR TITLE
Make TLS work without providing a ca cert file

### DIFF
--- a/octoprint_mqtt/__init__.py
+++ b/octoprint_mqtt/__init__.py
@@ -393,7 +393,7 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
             subbed_topic, subbed_callback, _, _ = entry
             return not (callback == subbed_callback and (topic is None or subbed_topic == topic))
 
-        self._mqtt_subscriptions = filter(remove_sub, self._mqtt_subscriptions)
+        self._mqtt_subscriptions = list(filter(remove_sub, self._mqtt_subscriptions))
 
         if self._mqtt_connected and subbed_topics:
             self._mqtt.unsubscribe(*subbed_topics)

--- a/octoprint_mqtt/__init__.py
+++ b/octoprint_mqtt/__init__.py
@@ -98,6 +98,7 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
                 username=None,
                 password=None,
                 keepalive=60,
+                tls_active=False,
                 tls=dict(),
                 tls_insecure=False,
                 protocol="MQTTv31",
@@ -275,6 +276,7 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
         broker_username = self._settings.get(["broker", "username"])
         broker_password = self._settings.get(["broker", "password"])
         broker_keepalive = self._settings.get_int(["broker", "keepalive"])
+        broker_tls_active = self._settings.get(["broker", "tls_active"])
         broker_tls = self._settings.get(["broker", "tls"], asdict=True)
         broker_tls_insecure = self._settings.get_boolean(["broker", "tls_insecure"])
         broker_protocol = self._settings.get(["broker", "protocol"])
@@ -298,17 +300,15 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
 
         if self._mqtt is None:
             self._mqtt = mqtt.Client(client_id=client_id, protocol=protocol, clean_session=clean_session)
+        else:
+            self._mqtt.reinitialise() #otherwise tls_set might be called again causing the plugin to crash 
 
         if broker_username is not None:
             self._mqtt.username_pw_set(broker_username, password=broker_password)
 
-        tls_active = False
-        if broker_tls:
+        if broker_tls_active:
             tls_args = dict((key, value) for key, value in broker_tls.items() if value)
-            ca_certs = tls_args.pop("ca_certs", None)
-            if ca_certs:  # cacerts must not be None for tls_set to work
-                self._mqtt.tls_set(ca_certs, **tls_args)
-                tls_active = True
+            self._mqtt.tls_set(**tls_args)
 
         if broker_tls_insecure and tls_active:
             self._mqtt.tls_insecure_set(broker_tls_insecure)

--- a/octoprint_mqtt/static/js/mqtt.js
+++ b/octoprint_mqtt/static/js/mqtt.js
@@ -5,7 +5,6 @@ $(function() {
         self.global_settings = parameters[0];
 
         self.showUserCredentials = ko.observable(false);
-        self.showSsl = ko.observable(false);
         self.showClientID = ko.observable(false);
 
         self.settings = undefined;
@@ -16,9 +15,6 @@ $(function() {
 
             // show credential options if username is set
             self.showUserCredentials(!!self.settings.broker.username());
-
-            // show SSL/TLS config options if any of the corresponding settings are set
-            self.showSsl(!!self.settings.broker.tls && !!self.settings.broker.tls.cacerts && !!self.settings.broker.tls.cacerts())
 
             // show client_id options if client_id is set
             self.showClientID(!!self.settings.client.client_id());

--- a/octoprint_mqtt/templates/mqtt_settings.jinja2
+++ b/octoprint_mqtt/templates/mqtt_settings.jinja2
@@ -107,52 +107,51 @@
             <div class="control-group">
                 <div class="controls">
                     <label class="checkbox">
-                        <input type="checkbox" data-bind="checked: showSsl"> {{ _('The broker requires TLS to connect, show SSL/TLS options') }}
+                        <input type="checkbox" data-bind="checked: settings.broker.tls_active"> {{ _('The broker requires TLS to connect (If you change from true to false, you need to restart OctoPrint)') }}
                     </label>
                 </div>
             </div>
-            <div data-bind="visible: showSsl" style="display: none">
-                <div class="control-group">
-                    <label class="control-label">{{ _('Path to server certificate chain') }}</label>
-                    <div class="controls">
-                        <input type="text" class="input-large" id="settings_plugin_mqtt_broker_tls_caCerts" data-bind="value: settings.broker.tls.ca_certs" />
-                        <span class="help-block">{{ _('Path to the server\'s certificate chain file. Mandatory, required for TLS to work.') }}</span>
-                    </div>
-                </div>
 
-                <div class="control-group">
-                    <label class="control-label">{{ _('Path to client certificate') }}</label>
-                    <div class="controls">
-                        <input type="text" class="input-large" id="settings_plugin_mqtt_broker_tls_certfile" data-bind="value: settings.broker.tls.certfile" />
-                        <span class="help-block">{{ _('Paths to the PEM encoded client certificate, <strong>must not be password protected</strong>, only necessary if broker requires client certificate authentication.') }}</span>
-                    </div>
-                </div>
-
-                <div class="control-group">
-                    <label class="control-label">{{ _('Path to client key') }}</label>
-                    <div class="controls">
-                        <input type="text" class="input-large" id="settings_plugin_mqtt_broker_tls_keyfile" data-bind="value: settings.broker.tls.keyfile" />
-                        <span class="help-block">{{ _('Paths to the PEM encoded private keys, <strong>must not be password protected</strong>, only necessary if broker requires client certificate authentication.') }}</span>
-                    </div>
-                </div>
-
-                <div class="advanced-options-container">
-                    <div><small><a href="#" class="muted" data-bind="toggleContent: { class: 'fa-caret-right fa-caret-down', parent: '.advanced-options-container', container: '.hide' }"><i class="fa fa-caret-right"></i> {{ _('Advanced TLS options') }}</a></small></div>
-                    <div class="hide">
-                        <div class="control-group">
-                            <label class="control-label">{{ _('Ciphers') }}</label>
-                            <div class="controls">
-                                <input type="text" class="input-large" id="settings_plugin_mqtt_broker_tls_ciphers" data-bind="value: settings.broker.tls.ciphers" />
-                                <span class="help-block">{{ _('A string specifying which encryption ciphers are allowable for this connection. See <a href="%(url)s" target="_blank">the OpenSSL documentation on ciphers</a>.', url = "https://www.openssl.org/docs/manmaster/man1/ciphers.html") }}</span>
-                            </div>
+            <div class="advanced-options-container">
+                <div><small><a href="#" class="muted" data-bind="toggleContent: { class: 'fa-caret-right fa-caret-down', parent: '.advanced-options-container', container: '.hide' }"><i class="fa fa-caret-right"></i> {{ _('Advanced TLS options') }}</a></small></div>
+                <div class="hide">
+                    <div class="control-group">
+                        <label class="control-label">{{ _('Path to server certificate chain') }}</label>
+                        <div class="controls">
+                            <input type="text" class="input-large" id="settings_plugin_mqtt_broker_tls_caCerts" data-bind="value: settings.broker.tls.ca_certs" />
+                            <span class="help-block">{{ _('Path to the server\'s certificate chain file (optional).') }}</span>
                         </div>
+                    </div>
 
-                        <div class="control-group">
-                            <div class="controls">
-                                <label class="checkbox">
-                                    <input type="checkbox" data-bind="checked: settings.broker.tls_insecure" /> {{ _('Do not verify the server hostname in the server certificate') }} <span class="label label-important">Caution</span>
-                                </label>
-                            </div>
+                    <div class="control-group">
+                        <label class="control-label">{{ _('Path to client certificate') }}</label>
+                        <div class="controls">
+                            <input type="text" class="input-large" id="settings_plugin_mqtt_broker_tls_certfile" data-bind="value: settings.broker.tls.certfile" />
+                            <span class="help-block">{{ _('Paths to the PEM encoded client certificate, <strong>must not be password protected</strong>, only necessary if broker requires client certificate authentication.') }}</span>
+                        </div>
+                    </div>
+
+                    <div class="control-group">
+                        <label class="control-label">{{ _('Path to client key') }}</label>
+                        <div class="controls">
+                            <input type="text" class="input-large" id="settings_plugin_mqtt_broker_tls_keyfile" data-bind="value: settings.broker.tls.keyfile" />
+                            <span class="help-block">{{ _('Paths to the PEM encoded private keys, <strong>must not be password protected</strong>, only necessary if broker requires client certificate authentication.') }}</span>
+                        </div>
+                    </div>
+                    
+                    <div class="control-group">
+                        <label class="control-label">{{ _('Ciphers') }}</label>
+                        <div class="controls">
+                            <input type="text" class="input-large" id="settings_plugin_mqtt_broker_tls_ciphers" data-bind="value: settings.broker.tls.ciphers" />
+                            <span class="help-block">{{ _('A string specifying which encryption ciphers are allowable for this connection. See <a href="%(url)s" target="_blank">the OpenSSL documentation on ciphers</a>.', url = "https://www.openssl.org/docs/manmaster/man1/ciphers.html") }}</span>
+                        </div>
+                    </div>
+
+                    <div class="control-group">
+                        <div class="controls">
+                            <label class="checkbox">
+                                <input type="checkbox" data-bind="checked: settings.broker.tls_insecure" /> {{ _('Do not verify the server hostname in the server certificate') }} <span class="label label-important">Caution</span>
+                            </label>
                         </div>
                     </div>
                 </div>

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ plugin_package = "octoprint_mqtt"
 plugin_name = "OctoPrint-MQTT"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.8.9"
+plugin_version = "0.8.10"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Fixes #89 

As described in #89, having to provide a ca cert file when using tls is not necessary and is quite painful if you work with certs that change automatically every four months (Let's encrypt). The paho-mqtt package allows `ca_certs` to be empty.
My idea was to get the value of the "Broker requires TLS" checkbox into the plugin settings. As you know, this value is already used for the visibility of the additional TLS settings and I wasn't able to keep it this way. That's why I stuffed all text fields into the "Advanced TLS options" which are always visible now. I know it's not perfect, but imho the additional functionality is worth it. Now looks like this:
![settings](https://user-images.githubusercontent.com/65307209/140586293-48cd2368-d780-462f-ab79-d797a3fc29e6.png)

I also added a `self._mqtt.reinitialise()` because when I tested, I ran into "TLS already set" errors which broke the connection until you restart OctoPrint. This is gone now.

There's one thing that still bothers me: When you change the "Broker requires TLS" from true to false, it seems that no reconnect is triggered. As if something is blocking... This only happens with my new TLS setting, all other checkboxes work fine. Interestingly, when you restart OctoPrint, you'll find that your settings were indeed saved, but the `on_settings_save` method wasn't triggered according to the logs. I added a comment in the checkbox but maybe you have an idea why that happens.

P.S.: I'm not a real dev... Be gentle ;-)