### PR TITLE
Add support for publishing additional metadata

### DIFF
--- a/octoprint_mqtt/__init__.py
+++ b/octoprint_mqtt/__init__.py
@@ -127,6 +127,10 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
                 temperatureActive=True,
                 temperatureThreshold=0.1,
 
+                metadataTopic="metadata/{key}",
+                metadataActive=False,
+                metadataKeys="",
+
                 lwTopic="mqtt",
                 lwActive=True
             ),
@@ -173,6 +177,10 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
         elif event == Events.FILE_DESELECTED:
             self.on_print_progress("", "", 0)
 
+
+        if event in [Events.PRINT_STARTED, Events.PRINT_DONE, Events.PRINT_FAILED, Events.PRINT_CANCELLED]:
+            self.on_additional_metadata(payload["origin"], payload["path"], event)
+
         topic = self._get_topic("event")
 
         if topic:
@@ -210,6 +218,57 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
                         destination_path=destination_path,
                         progress=progress)
             self.mqtt_publish_with_timestamp(topic.format(progress="slicing"), data)
+
+    ##~~ Additional Metadata
+
+    def on_additional_metadata(self, origin, path, event):
+        if not self._settings.get_boolean(["publish", "metadataActive"]):
+            return
+
+        keys = list(set([key.strip() for key in self._settings.get(["publish", "metadataKeys"]).split(",") if key.strip() != ""]))
+
+        if not keys:
+            self._logger.warn("No metadata keys defined, can't publish metadata")
+            return
+
+        topic = self._get_topic("metadata")
+
+        if not topic:
+            self._logger.warn("No metadata topic defined, can't publish metadata")
+            return
+
+        if event == Events.PRINT_STARTED:
+            storage = self._file_manager._storage(origin)
+            file = storage.path_on_disk(path)
+
+            def _get_nested_value(data, key):
+                first, _, rest = key.partition(".")
+                value = data.get(first)
+
+                if rest:
+                    return _get_nested_value(value, rest) if isinstance(value, dict) else None
+                else:
+                    return value
+
+            for key in keys:
+                if "." not in key:
+                    value = storage.get_additional_metadata(file, key)
+                else:
+                    first, _, rest = key.partition(".")
+                    data = storage.get_additional_metadata(file, first)
+                    value = _get_nested_value(data, rest) if isinstance(data, dict) else None
+
+                if isinstance(value, (dict, list)):
+                    value = json.dumps(value)
+
+                if not isinstance(value, (six.string_types, six.integer_types, float, bytearray, type(None))):
+                    self._logger.warn("Metadata key {key} is not a simple type, can't publish".format(key=key))
+                    continue
+
+                self.mqtt_publish(topic.format(key=key), value, raw_data=True)
+        elif event in [Events.PRINT_DONE, Events.PRINT_FAILED, Events.PRINT_CANCELLED]:
+            for key in keys:
+                self.mqtt_publish(topic.format(key=key), None, raw_data=True)
 
     ##~~ PrinterCallback
 
@@ -301,7 +360,7 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
         if self._mqtt is None:
             self._mqtt = mqtt.Client(client_id=client_id, protocol=protocol, clean_session=clean_session)
         else:
-            self._mqtt.reinitialise() #otherwise tls_set might be called again causing the plugin to crash 
+            self._mqtt.reinitialise() #otherwise tls_set might be called again causing the plugin to crash
 
         if broker_username is not None:
             self._mqtt.username_pw_set(broker_username, password=broker_password)

--- a/octoprint_mqtt/templates/mqtt_settings.jinja2
+++ b/octoprint_mqtt/templates/mqtt_settings.jinja2
@@ -138,7 +138,7 @@
                             <span class="help-block">{{ _('Paths to the PEM encoded private keys, <strong>must not be password protected</strong>, only necessary if broker requires client certificate authentication.') }}</span>
                         </div>
                     </div>
-                    
+
                     <div class="control-group">
                         <label class="control-label">{{ _('Ciphers') }}</label>
                         <div class="controls">
@@ -294,6 +294,37 @@
                     </div>
                 </div>
             </fieldset>
+
+            <fieldset>
+                <legend>{{ _('Additional Metadata') }}</legend>
+                <div class="control-group">
+                    <div class="controls">
+                        <label class="checkbox">
+                            <input type="checkbox" data-bind="checked:  settings.publish.metadataActive" /> {{ _('Activate additional metadata messages') }}
+                        </label>
+                        <span class="help-block">{{ _('Enable this option to publish additional metadata on print start. This feature is useful when using plugins like OctoPrint-SlicerSettingsParser.') }}</span>
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">{{ _('Topic') }}</label>
+                    <div class="controls">
+                        <div class="input-prepend">
+                            <span class="add-on" data-bind="text: settings.publish.baseTopic"></span>
+                            <input type="text" class="input-large" id="settings_plugin_mqtt_publish_metadataTopic" data-bind="value: settings.publish.metadataTopic" />
+                        </div>
+                        <span class="help-block">{{ _('Topic for additional metadata, appended to the base topic, <code>{key}</code> will be substituted with the the key name.') }}</span>
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">{{ _('Keys') }}</label>
+                    <div class="controls">
+                        <input type="text" class="input-large" id="settings_plugin_mqtt_publish_metadataKeys" data-bind="value: settings.publish.metadataKeys" />
+                        <span class="help-block">{{ _('Enter a comma-separated list of keys for the additional metadata to publish.') }}</span>
+                        <span class="help-block">{{ _('To publish specific pieces of data nested in dictionaries, use dot notation. For example: <code>slicer_settings.material_type</code>.') }}</span>
+                        <span class="help-block">{{ _('Dot notation can be used recursively to access deeper levels. For example: <code>slicer_settings.material_settings.density</code>.') }}</span>
+                    </div>
+                </div>
+            </fieldset>
         </div>
         <div id="settings_plugin_mqtt_lastwill" class="tab-pane">
             <span class="help-block">{{ _('Enable this to get a <code>connected</code> message published to the topic on connect of the client, and a <code>disconnected</code> message on disconnect (via the broker\'s last will mechanism). See <a href="%(url)s" target="_blank", rel="noopener noreferrer">here</a> for more information on the Last Will concept in MQTT.', url="https://www.hivemq.com/blog/mqtt-essentials-part-9-last-will-and-testament") }}</span>
@@ -319,4 +350,3 @@
 </form>
 
 <p class="muted"><small>{{ _('If you need help on setting up this plugin, please have a look at <a href="%(url)s" target="_blank">the documentation on Github</a>.', url = "https://github.com/OctoPrint/OctoPrint-MQTT/blob/master/README.md") }}</small></p>
-


### PR DESCRIPTION
Adds support for publishing additional metadata on print start.

This is especially useful in combination with [OctoPrint-SlicerSettingsParser](https://plugins.octoprint.org/plugins/SlicerSettingsParser/).

Personally I'm using it to tell Home Assistant the material type, so it can configure the enclosure accordingly.