### PR TITLE
Fixing connect/disconnect and adding UI elements - connect/disconnect buttons and status indicator

### DIFF
--- a/octoprint_mqtt/__init__.py
+++ b/octoprint_mqtt/__init__.py
@@ -417,6 +417,12 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
                 _retain = self._settings.get_boolean(["broker", "lwRetain"])
                 self._mqtt.publish(lwt, self.LWT_DISCONNECTED, qos=1, retain=_retain)
 
+        # Actually disconnect from the broker
+        try:
+            self._mqtt.disconnect()
+        except:
+            pass  # Ignore errors if already disconnected
+
         self._mqtt.loop_stop()
 
         if force:

--- a/octoprint_mqtt/__init__.py
+++ b/octoprint_mqtt/__init__.py
@@ -589,6 +589,9 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
 
             self._mqtt_connected = True
 
+            # Notify frontend of connection status change
+            self._plugin_manager.send_plugin_message(self._identifier, {"connected": True})
+
             if self._mqtt_reset_state:
                 self._update_progress("", "")
                 self.on_slicing_progress("", "", "", "", "", 0)
@@ -606,6 +609,12 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
             self._logger.info("Disconnected from mqtt broker")
 
         self._mqtt_connected = False
+
+        # Notify frontend of connection status change
+        try:
+            self._plugin_manager.send_plugin_message(self._identifier, {"connected": False})
+        except Exception as e:
+            self._logger.error("Exception while sending disconnect message to frontend: {}".format(e), exc_info=True)
 
     def _on_mqtt_message(self, client, userdata, msg):
         if not client == self._mqtt:

--- a/octoprint_mqtt/static/js/mqtt.js
+++ b/octoprint_mqtt/static/js/mqtt.js
@@ -161,6 +161,17 @@ $(function() {
                 }
             });
         };
+
+        // Handle plugin messages from backend for real-time connection status updates
+        self.onDataUpdaterPluginMessage = function(plugin, data) {
+            if (plugin !== "mqtt") {
+                return;
+            }
+
+            if (data.hasOwnProperty("connected")) {
+                self.updateConnectionStatus(data.connected);
+            }
+        };
     }
 
     ADDITIONAL_VIEWMODELS.push([

--- a/octoprint_mqtt/static/js/mqtt.js
+++ b/octoprint_mqtt/static/js/mqtt.js
@@ -25,7 +25,7 @@ $(function() {
         });
 
         self.connectButtonEnabled = ko.pureComputed(function() {
-            return !self.isConnecting() && !self.isDisconnecting();
+            return !self.isConnecting() && !self.isDisconnecting() && !self.isConnected();
         });
 
         self.connectButtonHtml = ko.pureComputed(function() {
@@ -37,7 +37,7 @@ $(function() {
         });
 
         self.disconnectButtonEnabled = ko.pureComputed(function() {
-            return !self.isConnecting() && !self.isDisconnecting();
+            return !self.isConnecting() && !self.isDisconnecting() && self.isConnected();
         });
 
         self.disconnectButtonHtml = ko.pureComputed(function() {

--- a/octoprint_mqtt/static/js/mqtt.js
+++ b/octoprint_mqtt/static/js/mqtt.js
@@ -18,6 +18,121 @@ $(function() {
 
             // show client_id options if client_id is set
             self.showClientID(!!self.settings.client.client_id());
+
+            // check connection status on load
+            self.checkConnectionStatus();
+        };
+
+        self.checkConnectionStatus = function() {
+            $.ajax({
+                url: API_BASEURL + "plugin/mqtt",
+                type: "GET",
+                dataType: "json",
+                success: function(response) {
+                    self.updateConnectionStatus(response.connected);
+                },
+                error: function() {
+                    self.updateConnectionStatus(false);
+                }
+            });
+        };
+
+        self.updateConnectionStatus = function(connected) {
+            var statusElement = $("#mqtt_connection_status");
+            if (connected) {
+                statusElement.html('<i class="fa fa-check-circle" style="color: green;"></i> <span style="color: green;">Connected</span>');
+            } else {
+                statusElement.html('<i class="fa fa-times-circle" style="color: #d9534f;"></i> <span style="color: #d9534f;">Disconnected</span>');
+            }
+        };
+
+        self.connectMqtt = function() {
+            var button = $("#mqtt_connect_button");
+            button.prop("disabled", true);
+            button.html('<i class="fa fa-spinner fa-spin"></i> Connecting...');
+
+            $.ajax({
+                url: API_BASEURL + "plugin/mqtt",
+                type: "POST",
+                dataType: "json",
+                data: JSON.stringify({
+                    command: "connect"
+                }),
+                contentType: "application/json; charset=UTF-8",
+                success: function(response) {
+                    if (response.connected) {
+                        new PNotify({
+                            title: "MQTT Connected",
+                            text: "Successfully connected to MQTT broker",
+                            type: "success"
+                        });
+                        self.updateConnectionStatus(true);
+                    } else {
+                        new PNotify({
+                            title: "MQTT Connection",
+                            text: "Connection initiated, but not yet established. Check broker settings.",
+                            type: "warning"
+                        });
+                        self.updateConnectionStatus(false);
+                    }
+                },
+                error: function() {
+                    new PNotify({
+                        title: "MQTT Connection Failed",
+                        text: "Failed to connect to MQTT broker. Check logs for details.",
+                        type: "error"
+                    });
+                    self.updateConnectionStatus(false);
+                },
+                complete: function() {
+                    button.prop("disabled", false);
+                    button.html('<i class="fa fa-link"></i> Connect');
+                }
+            });
+        };
+
+        self.disconnectMqtt = function() {
+            var button = $("#mqtt_disconnect_button");
+            button.prop("disabled", true);
+            button.html('<i class="fa fa-spinner fa-spin"></i> Disconnecting...');
+
+            $.ajax({
+                url: API_BASEURL + "plugin/mqtt",
+                type: "POST",
+                dataType: "json",
+                data: JSON.stringify({
+                    command: "disconnect"
+                }),
+                contentType: "application/json; charset=UTF-8",
+                success: function(response) {
+                    if (!response.connected) {
+                        new PNotify({
+                            title: "MQTT Disconnected",
+                            text: "Successfully disconnected from MQTT broker",
+                            type: "success"
+                        });
+                        self.updateConnectionStatus(false);
+                    } else {
+                        new PNotify({
+                            title: "MQTT Disconnection",
+                            text: "Disconnect initiated, but still showing as connected.",
+                            type: "warning"
+                        });
+                        self.updateConnectionStatus(true);
+                    }
+                },
+                error: function() {
+                    new PNotify({
+                        title: "MQTT Disconnection Failed",
+                        text: "Failed to disconnect from MQTT broker. Check logs for details.",
+                        type: "error"
+                    });
+                },
+                complete: function() {
+                    button.prop("disabled", false);
+                    button.html('<i class="fa fa-unlink"></i> Disconnect');
+                }
+            });
         };
     }
 

--- a/octoprint_mqtt/templates/mqtt_settings.jinja2
+++ b/octoprint_mqtt/templates/mqtt_settings.jinja2
@@ -8,6 +8,21 @@
     <div class="tab-content">
         <div id="settings_plugin_mqtt_broker" class="tab-pane active">
             <div class="control-group">
+                <label class="control-label">{{ _('Connection Status') }}</label>
+                <div class="controls">
+                    <span id="mqtt_connection_status" style="display: inline-flex; align-items: center; gap: 5px;">
+                        <i class="fa fa-spinner fa-spin"></i>
+                        <span>{{ _('Checking...') }}</span>
+                    </span>
+                    <button class="btn btn-danger btn-small" id="mqtt_disconnect_button" data-bind="click: disconnectMqtt" style="margin-left: 10px;">
+                        <i class="fa fa-unlink"></i> {{ _('Disconnect') }}
+                    </button>
+                    <button class="btn btn-success btn-small" id="mqtt_connect_button" data-bind="click: connectMqtt">
+                        <i class="fa fa-link"></i> {{ _('Connect') }}
+                    </button>
+                </div>
+            </div>
+            <div class="control-group">
                 <label class="control-label">{{ _('Host') }}</label>
                 <div class="controls">
                     <input type="text" class="input-large" id="settings_plugin_mqtt_broker_url" data-bind="value: settings.broker.url" />

--- a/octoprint_mqtt/templates/mqtt_settings.jinja2
+++ b/octoprint_mqtt/templates/mqtt_settings.jinja2
@@ -10,16 +10,9 @@
             <div class="control-group">
                 <label class="control-label">{{ _('Connection Status') }}</label>
                 <div class="controls">
-                    <span id="mqtt_connection_status" style="display: inline-flex; align-items: center; gap: 5px;">
-                        <i class="fa fa-spinner fa-spin"></i>
-                        <span>{{ _('Checking...') }}</span>
-                    </span>
-                    <button class="btn btn-danger btn-small" id="mqtt_disconnect_button" data-bind="click: disconnectMqtt" style="margin-left: 10px;">
-                        <i class="fa fa-unlink"></i> {{ _('Disconnect') }}
-                    </button>
-                    <button class="btn btn-success btn-small" id="mqtt_connect_button" data-bind="click: connectMqtt">
-                        <i class="fa fa-link"></i> {{ _('Connect') }}
-                    </button>
+                    <span style="display: inline-flex; align-items: center; gap: 5px;" data-bind="html: connectionStatusHtml"></span>
+                    <button class="btn btn-danger btn-small" data-bind="click: disconnectMqtt, enable: disconnectButtonEnabled, html: disconnectButtonHtml" style="margin-left: 10px;"></button>
+                    <button class="btn btn-success btn-small" data-bind="click: connectMqtt, enable: connectButtonEnabled, html: connectButtonHtml"></button>
                 </div>
             </div>
             <div class="control-group">

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ plugin_url = "https://github.com/OctoPrint/OctoPrint-MQTT"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ["OctoPrint>=1.3.5", "six", "paho-mqtt<2"]
+plugin_requires = ["OctoPrint>=1.3.5", "six", "paho-mqtt>=1.4.0,<2"]
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
This PR addresses the issue where OctoPrint-MQTT fails to reconnect after the MQTT broker (Home Assistant) restarts.  See #151 

_Note: It was also requested to merge with devel branch, but it is 14 commit behind master, so I am not sure it makes sense._

# Bug Fixes

## 1. Fixed MQTT disconnect/reconnect logic
- **Problem**: The `mqtt_disconnect()` method never called `self._mqtt.disconnect()`, so the broker didn't receive a      
proper disconnect packet. This caused reconnection attempts to fail because the broker thought the client was still       
connected.
- **Solution**:
- Added `self._mqtt.disconnect()` call before stopping the network loop

## 2. Fixed invalid topic subscription error
- **Problem**: When reconnecting, the plugin attempted to subscribe to topics from the subscription list, but some        
entries had invalid/empty topic values, causing a `ValueError: Invalid topic` exception. This prevented
`_mqtt_connected` from being set to `True`.
- **Solution**:
- Added filtering to exclude invalid topics (None or empty strings) before subscribing
- Added exception handling in `_on_mqtt_connect()` to log errors without breaking the connection

# New Features

## Added manual Connect/Disconnect controls in settings UI
- Added **Connection Status** indicator showing real-time connection state (Connected/Disconnected)
- Added **Disconnect** button (red) to manually disconnect from broker
- Added **Connect** button (green) to manually reconnect to broker
- Implemented `SimpleApiPlugin` with admin-only API endpoints:
- `POST /api/plugin/mqtt` with command `connect` - initiates connection
- `POST /api/plugin/mqtt` with command `disconnect` - disconnects from broker
- `GET /api/plugin/mqtt` - returns current connection status
- Connection status uses `is_connected()` from Paho MQTT client for accurate real-time status

# Benefits
- Users can now manually reconnect to MQTT broker after Home Assistant restarts without restarting OctoPrint
- Visual feedback shows current connection state
- Proper disconnect/reconnect sequence ensures clean broker sessions
- Admin-only API access ensures security

# Screenshots

<img width="681" height="182" alt="image" src="https://github.com/user-attachments/assets/b5529850-6394-479c-83e5-63ce6f5f5603" />

<img width="564" height="109" alt="image" src="https://github.com/user-attachments/assets/e1178f5a-9bd9-4657-81fb-9afad3d7c2f9" />

