### PR TITLE
fix: make compatible to paho-mqtt 2.x

### DIFF
--- a/octoprint_mqtt/__init__.py
+++ b/octoprint_mqtt/__init__.py
@@ -381,7 +381,7 @@ class MqttPlugin(octoprint.plugin.SettingsPlugin,
             protocol = mqtt.MQTTv31
 
         if self._mqtt is None:
-            self._mqtt = mqtt.Client(client_id=client_id, protocol=protocol, clean_session=clean_session)
+            self._mqtt = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, client_id=client_id, protocol=protocol, clean_session=clean_session)
         else:
             self._mqtt.reinitialise() #otherwise tls_set might be called again causing the plugin to crash
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ plugin_url = "https://github.com/OctoPrint/OctoPrint-MQTT"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ["OctoPrint>=1.3.5", "six", "paho-mqtt<2"]
+plugin_requires = ["OctoPrint>=1.3.5", "six", "paho-mqtt>=2,<3"]
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point
@@ -65,9 +65,12 @@ from setuptools import setup
 try:
     import octoprint_setuptools
 except:
-    print("Could not import OctoPrint's setuptools, are you sure you are running that under "
-          "the same python installation that OctoPrint is installed under?")
+    print(
+        "Could not import OctoPrint's setuptools, are you sure you are running that under "
+        "the same python installation that OctoPrint is installed under?"
+    )
     import sys
+
     sys.exit(-1)
 
 setup_parameters = octoprint_setuptools.create_plugin_setup_parameters(
@@ -83,11 +86,12 @@ setup_parameters = octoprint_setuptools.create_plugin_setup_parameters(
     requires=plugin_requires,
     additional_packages=plugin_additional_packages,
     ignored_packages=plugin_ignored_packages,
-    additional_data=plugin_additional_data
+    additional_data=plugin_additional_data,
 )
 
 if len(additional_setup_parameters):
     from octoprint.util import dict_merge
+
     setup_parameters = dict_merge(setup_parameters, additional_setup_parameters)
 
 setup(**setup_parameters)


### PR DESCRIPTION
TODO: This only makes the plugin work against paho-mqtt 2+, however through a deprecated client interface. This NEEDS to be migrated to 2.0 client code as soon as possible.

See https://eclipse.dev/paho/files/paho.mqtt.python/html/migrations.html for a migration guide.

(PS: Contrary to template *not* done against `devel` as that seems to be stale)